### PR TITLE
Add touch screen support for minesweeper game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,8 +19,7 @@ function App() {
     timeDiff,
     startNewGame,
     restartGame,
-    handleCellLeftClick,
-    handleCellRightClick,
+    handleCellInteraction,
     isGameWin,
     isGameOver,
     isGameEnded,
@@ -39,8 +38,7 @@ function App() {
       />
       <Board
         gameBoard={gameBoard}
-        handleCellLeftClick={handleCellLeftClick}
-        handleCellRightClick={handleCellRightClick}
+        handleCellInteraction={handleCellInteraction}
         level={level}
       />
       <SelectLevel level={level} changeLevel={changeLevel} />

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,12 +1,11 @@
-import { memo, MouseEvent } from "react";
+import { memo } from "react";
 import { TBoard, TLevel } from "../types";
 import Cell from "./Cell";
 
 type BoardProps = {
   gameBoard: TBoard;
-  handleCellLeftClick: (row: number, col: number) => void;
-  handleCellRightClick: (
-    e: MouseEvent<HTMLDivElement>,
+  handleCellInteraction: (
+    e: globalThis.PointerEvent,
     row: number,
     col: number
   ) => void;
@@ -16,8 +15,7 @@ type BoardProps = {
 const Board = memo(
   ({
     gameBoard,
-    handleCellLeftClick,
-    handleCellRightClick,
+    handleCellInteraction,
     level,
   }: BoardProps) => {
     return (
@@ -29,8 +27,7 @@ const Board = memo(
                 cell={cell}
                 rowIndex={rowIndex}
                 cellIndex={cellIndex}
-                handleCellLeftClick={handleCellLeftClick}
-                handleCellRightClick={handleCellRightClick}
+                handleCellInteraction={handleCellInteraction}
                 level={level}
                 key={cellIndex}
               />

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,5 +1,5 @@
 // Core
-import { MouseEvent, memo } from "react";
+import { memo, PointerEvent, MouseEvent } from "react";
 import clsx from "clsx";
 import { CELL_NUMBERS_COLORS } from "../constants";
 
@@ -15,23 +15,29 @@ type Props = {
   rowIndex: number;
   cellIndex: number;
   level: TLevel;
-  handleCellLeftClick: (row: number, col: number) => void;
-  handleCellRightClick: (
-    e: MouseEvent<HTMLDivElement>,
+  handleCellInteraction: (
+    e: globalThis.PointerEvent,
     row: number,
     col: number
   ) => void;
 };
 
 const Cell = (props: Props) => {
-  const {
-    cell,
-    rowIndex,
-    cellIndex,
-    level,
-    handleCellLeftClick,
-    handleCellRightClick,
-  } = props;
+  const { cell, rowIndex, cellIndex, level, handleCellInteraction } = props;
+
+  const onPointerEvent = (e: PointerEvent<HTMLDivElement>) =>
+    handleCellInteraction(
+      e.nativeEvent as unknown as globalThis.PointerEvent,
+      rowIndex,
+      cellIndex
+    );
+
+  const onContextMenu = (e: MouseEvent<HTMLDivElement>) =>
+    handleCellInteraction(
+      e.nativeEvent as unknown as globalThis.PointerEvent,
+      rowIndex,
+      cellIndex
+    );
 
   return (
     <div
@@ -41,8 +47,9 @@ const Cell = (props: Props) => {
         typeof cell.value === "number" && CELL_NUMBERS_COLORS[cell.value],
         level !== "easy" && "small"
       )}
-      onClick={() => handleCellLeftClick(rowIndex, cellIndex)}
-      onContextMenu={(e) => handleCellRightClick(e, rowIndex, cellIndex)}
+      onPointerDown={onPointerEvent}
+      onPointerUp={onPointerEvent}
+      onContextMenu={onContextMenu}
     >
       {cell.value === "mine" && <img src={mineIcon} />}
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -46,3 +46,5 @@ export const LEVELS = {
 };
 
 export const DEFAULT_LEVEL: TLevel = "easy";
+
+export const HOLD_TIME = 300;

--- a/src/hooks/useMinesweeperGame.tsx
+++ b/src/hooks/useMinesweeperGame.tsx
@@ -1,10 +1,10 @@
 // Core
-import { MouseEvent, useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import useTimer from "./useTimer";
 import useSFX from "./useSFX";
 
 // Constants
-import { DEFAULT_LEVEL, LEVELS } from "../constants";
+import { DEFAULT_LEVEL, LEVELS, HOLD_TIME } from "../constants";
 
 // Utils
 import {
@@ -150,89 +150,144 @@ const useMinesweeperGame = () => {
     [currentLevel, isTimerRunning, playSoundEffect, startTimer]
   );
 
-  const handleCellLeftClick = useCallback(
-    (row: number, col: number) => {
-      if (
-        isGameEnded ||
-        gameBoard[row][col].isOpened ||
-        gameBoard[row][col].isFlagged
-      ) {
-        return null;
+  const shouldOpenCell = (row: number, col: number): boolean => {
+    if (
+      isGameEnded ||
+      gameBoard[row][col].isOpened ||
+      gameBoard[row][col].isFlagged
+    ) {
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleOpenCell = (row: number, col: number) => {
+    const mineCell = gameBoard[row][col].value === "mine";
+    const isFirstClick = !isTimerRunning;
+    const isFirstClickOnMine = mineCell && isFirstClick;
+
+    let newGameBoard: TBoard;
+
+    if (isFirstClickOnMine) {
+      do {
+        newGameBoard = initBoard(
+          currentLevel.rows,
+          currentLevel.cols,
+          currentLevel.totalMines
+        );
+      } while (newGameBoard[row][col].value === "mine");
+    } else {
+      newGameBoard = JSON.parse(JSON.stringify(gameBoard));
+    }
+
+    const boardAfterOpeningCell = openCell(newGameBoard, row, col);
+
+    if (boardAfterOpeningCell) {
+      setGameBoard(boardAfterOpeningCell);
+    }
+  };
+
+  const shouldToggleFlag = (row: number, col: number): boolean => {
+    if (isGameEnded || gameBoard[row][col].isOpened) return false;
+
+    return true;
+  };
+
+  const toggleFlag = (row: number, col: number) => {
+    if (!isTimerRunning) startTimer();
+
+    let flagsDiff = 0;
+
+    setGameBoard((prevGameBoard) => {
+      const newGameBoard: TBoard = JSON.parse(JSON.stringify(prevGameBoard));
+      const cell = prevGameBoard[row][col];
+
+      if (cell.isFlagged) {
+        newGameBoard[row][col].isFlagged = false;
+        if (!flagsDiff) flagsDiff--;
+        playSoundEffect("FLAG_REMOVE");
       }
 
-      const mineCell = gameBoard[row][col].value === "mine";
-      const isFirstClick = !isTimerRunning;
-      const isFirstClickOnMine = mineCell && isFirstClick;
-
-      let newGameBoard: TBoard;
-
-      if (isFirstClickOnMine) {
-        do {
-          newGameBoard = initBoard(
-            currentLevel.rows,
-            currentLevel.cols,
-            currentLevel.totalMines
-          );
-        } while (newGameBoard[row][col].value === "mine");
-      } else {
-        newGameBoard = JSON.parse(JSON.stringify(gameBoard));
+      if (!cell.isFlagged) {
+        newGameBoard[row][col].isFlagged = true;
+        if (!flagsDiff) flagsDiff++;
+        playSoundEffect("FLAG_PLACE");
       }
 
-      const boardAfterOpeningCell = openCell(newGameBoard, row, col);
-
-      if (boardAfterOpeningCell) {
-        setGameBoard(boardAfterOpeningCell);
+      if (checkGameWin(newGameBoard, currentLevel.totalMines)) {
+        revealAllMines(newGameBoard, true);
+        setIsGameWin(true);
+        playSoundEffect("GAME_WIN");
       }
-    },
-    [isGameEnded, gameBoard, isTimerRunning, openCell, currentLevel]
-  );
 
-  const handleCellRightClick = useCallback(
-    (e: MouseEvent<HTMLDivElement>, row: number, col: number) => {
+      return newGameBoard;
+    });
+
+    setTotalFlags((prevTotalFlags) => prevTotalFlags + flagsDiff);
+  };
+
+  const touchDownTimeRef = useRef<number | null>(null);
+  const touchHoldTimeoutRef = useRef<null | number>(null);
+
+  const cleanupTimers = () => {
+    clearTimeout(touchHoldTimeoutRef.current!);
+    touchHoldTimeoutRef.current = null;
+    touchDownTimeRef.current = null;
+  };
+
+  const handleCellInteraction = (e: PointerEvent, row: number, col: number) => {
+    const isLeftClick =
+      e.type === "pointerup" && e.button === 0 && e.pointerType === "mouse";
+    const isRightClick = e.type === "contextmenu" && e.button === 2; // test with real mouse
+
+    const isTouchDown = e.type === "pointerdown" && e.pointerType === "touch";
+    const isTouchUp = e.type === "pointerup" && e.pointerType === "touch";
+
+    const contextMenuByHoldingFinger =
+      e.button === -1 && e.type === "contextmenu";
+
+    if (isLeftClick) {
+      if (shouldOpenCell(row, col)) {
+        handleOpenCell(row, col);
+      }
+    }
+
+    if (isRightClick) {
       e.preventDefault();
 
-      if (isGameEnded || gameBoard[row][col].isOpened) return;
+      if (shouldToggleFlag(row, col)) {
+        toggleFlag(row, col);
+      }
+    }
 
-      if (!isTimerRunning) startTimer();
+    if (isTouchUp) {
+      e.preventDefault();
 
-      let flagsDiff = 0;
+      const touchUpTime = new Date().getTime();
 
-      setGameBoard((prevGameBoard) => {
-        const newGameBoard: TBoard = JSON.parse(JSON.stringify(prevGameBoard));
-        const cell = prevGameBoard[row][col];
-
-        if (cell.isFlagged) {
-          newGameBoard[row][col].isFlagged = false;
-          if (!flagsDiff) flagsDiff--;
-          playSoundEffect("FLAG_REMOVE");
+      if (touchUpTime - touchDownTimeRef.current! < HOLD_TIME) {
+        if (shouldOpenCell(row, col)) {
+          handleOpenCell(row, col);
         }
+      }
 
-        if (!cell.isFlagged) {
-          newGameBoard[row][col].isFlagged = true;
-          if (!flagsDiff) flagsDiff++;
-          playSoundEffect("FLAG_PLACE");
-        }
+      cleanupTimers();
+    }
 
-        if (checkGameWin(newGameBoard, currentLevel.totalMines)) {
-          revealAllMines(newGameBoard, true);
-          setIsGameWin(true);
-          playSoundEffect("GAME_WIN");
-        }
+    if (isTouchDown && shouldToggleFlag(row, col)) {
+      touchDownTimeRef.current = new Date().getTime();
 
-        return newGameBoard;
-      });
+      touchHoldTimeoutRef.current = setTimeout(() => {
+        toggleFlag(row, col);
+        cleanupTimers();
+      }, HOLD_TIME);
+    }
 
-      setTotalFlags((prevTotalFlags) => prevTotalFlags + flagsDiff);
-    },
-    [
-      gameBoard,
-      isGameEnded,
-      isTimerRunning,
-      currentLevel.totalMines,
-      playSoundEffect,
-      startTimer,
-    ]
-  );
+    if (contextMenuByHoldingFinger) {
+      e.preventDefault();
+    }
+  };
 
   return {
     level,
@@ -242,8 +297,7 @@ const useMinesweeperGame = () => {
     timeDiff,
     startNewGame,
     restartGame,
-    handleCellLeftClick,
-    handleCellRightClick,
+    handleCellInteraction,
     isGameWin,
     isGameOver,
     isGameEnded,


### PR DESCRIPTION
- Replace mouse click handlers with pointer events for better touch support
- Add touch hold functionality for flagging cells (300ms hold time)
- Support both mouse and touch interactions
- Maintain backward compatibility with mouse users
- Add HOLD_TIME constant for configurable touch hold duration